### PR TITLE
Makefile: remove npm cache clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ install-backend:
 	cd backend && npm install
 
 cache-clean:
-	npm cache clean
 	bower cache clean
 
 test: test-backend test-frontend


### PR DESCRIPTION
From npm 5.x on, npm cache is healing itself and a cache clean is not
neccessary anymore