### PR TITLE
lock the UCS version to 4.1.3

### DIFF
--- a/tools/docker/ucs/Dockerfile
+++ b/tools/docker/ucs/Dockerfile
@@ -1,4 +1,4 @@
-FROM univention/ucs-master-amd64
+FROM univention/ucs-master-amd64:4.1-3
 
 EXPOSE 80 389 636
 


### PR DESCRIPTION
4.2 currently breaks the installation script